### PR TITLE
Add write permissions to TagBot.

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -7,6 +7,8 @@ on:
     inputs:
       lookback:
         default: 3
+permissions:
+    contents: write
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
TagBot didn't work properly when the most recent version of the package was added in the Julia registry. The last comment in [this](https://discourse.julialang.org/t/slow-tagbot-no-repo-update-after-16-hours/80870/2) discussion  mentions a fix; to add write permissions to `TagBot.yml`.