### PR TITLE
Reduce requirements for interpolation, bias correction & outlier removal

### DIFF
--- a/src/data_cleaning/bias_correction.jl
+++ b/src/data_cleaning/bias_correction.jl
@@ -36,7 +36,7 @@ bias_PSTT2021(radiance_datacube, ncfobs_datacube)
 function bias_PSTT2021(radiance_datacube, ncfobs_datacube, mask=ones(Int8, (size(radiance_datacube)[1],size(radiance_datacube)[2])))
     for i in 1:size(radiance_datacube)[1]
         for j in 1:size(radiance_datacube)[2]
-            if count(i->(ismissing(i)),radiance_datacube[i, j, :])/length(radiance_datacube[i, j, :]) > 0.50 
+            if count(i->(ismissing(i)),radiance_datacube[i, j, :])/length(radiance_datacube[i, j, :]) > 0.90 
                 continue
             end
             if ismissing(mask[i, j])

--- a/src/data_cleaning/interpolation.jl
+++ b/src/data_cleaning/interpolation.jl
@@ -10,7 +10,7 @@ na_interp_linear(x)
 ```
 """
 function na_interp_linear(timeseries)
-    if  count(i->(ismissing(i)), timeseries) > length(timeseries) *1/2
+    if  count(i->(ismissing(i)), timeseries) > length(timeseries) *0.9
         return zero(1:length(timeseries))
     end
     data = copy(timeseries)

--- a/src/data_cleaning/outlier_removal.jl
+++ b/src/data_cleaning/outlier_removal.jl
@@ -19,7 +19,7 @@ function outlier_variance(radiance_datacube, mask=ones(Int8, (size(radiance_data
             if ismissing(mask[i, j])
                 continue
             end
-            if count(i->(ismissing(i)),radiance_datacube[i, j, :])/length(radiance_datacube[i, j, :]) > 0.50  # Don't do anything if there are too many missings
+            if count(i->(ismissing(i)),radiance_datacube[i, j, :])/length(radiance_datacube[i, j, :]) > 0.90  # Don't do anything if there are too many missings
                 continue
             end
             stds[i, j] = std(detrend_ts(filter(x -> !ismissing(x), radiance_datacube[i, j, :])))


### PR DESCRIPTION
We weren't cleaning pixels with more than 50% missing values. I propose reducing this constraint to 90%. 

Some functions like `fit(SmoothingSpline, ... )` may not work with too many missing observations. We will need to test this by creating artificial missing values. 